### PR TITLE
Added composer support & polished some codestyle.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .idea
 db2/
+/vendor
+

--- a/README.md
+++ b/README.md
@@ -4,7 +4,23 @@ This is a small library to read DB2 and ADB files (data tables) from World of Wa
 
 ## Installation
 
-Just copy the class file into your project and include it where you want to use it. Eventually I want to make this compatible with Composer, but that's not done yet.
+Just copy the class file into your project and include it where you want to use it.
+
+#### Install with [Composer](https://getcomposer.org/)
+
+Run composer from your project directory:
+```sh
+$ composer.phar require erorus/db2
+```
+
+Or add it manually to your composer.json file:
+```json
+{
+    "require" : {
+        "erorus/db2": "*"
+    }
+}
+```
 
 ## Usage
 

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,23 @@
+{
+    "name":        "erorus/db2",
+    "description": "This is a small library to read DB2 and ADB files (data tables) from World of Warcraft.",
+    "license":     "Apache-2.0",
+    "require-dev": {
+        "phpunit/phpunit": "5.*"
+    },
+    "autoload": {
+        "psr-4": {
+            "Erorus\\DB2\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "": "test/"
+        }
+    },
+    "archive": {
+        "exclude": [
+            "/test"
+        ]
+    }
+}

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,1320 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "hash": "f067302b0ee835d6afb2a6c8570868ae",
+    "content-hash": "36ae5b16fe9a1891cd7f9efa4f5b0084",
+    "packages": [],
+    "packages-dev": [
+        {
+            "name": "doctrine/instantiator",
+            "version": "1.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/8e884e78f9f0eb1329e445619e04456e64d8051d",
+                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3,<8.0-DEV"
+            },
+            "require-dev": {
+                "athletic/athletic": "~0.1.8",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpunit/phpunit": "~4.0",
+                "squizlabs/php_codesniffer": "~2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "http://ocramius.github.com/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://github.com/doctrine/instantiator",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "time": "2015-06-14 21:17:01"
+        },
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.5.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "ea74994a3dc7f8d2f65a06009348f2d63c81e61f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/ea74994a3dc7f8d2f65a06009348f2d63c81e61f",
+                "reference": "ea74994a3dc7f8d2f65a06009348f2d63c81e61f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "doctrine/collections": "1.*",
+                "phpunit/phpunit": "~4.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "homepage": "https://github.com/myclabs/DeepCopy",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "time": "2016-09-16 13:37:59"
+        },
+        {
+            "name": "phpdocumentor/reflection-common",
+            "version": "1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
+                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
+            "homepage": "http://www.phpdoc.org",
+            "keywords": [
+                "FQSEN",
+                "phpDocumentor",
+                "phpdoc",
+                "reflection",
+                "static analysis"
+            ],
+            "time": "2015-12-27 11:43:31"
+        },
+        {
+            "name": "phpdocumentor/reflection-docblock",
+            "version": "3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "8331b5efe816ae05461b7ca1e721c01b46bafb3e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/8331b5efe816ae05461b7ca1e721c01b46bafb3e",
+                "reference": "8331b5efe816ae05461b7ca1e721c01b46bafb3e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5",
+                "phpdocumentor/reflection-common": "^1.0@dev",
+                "phpdocumentor/type-resolver": "^0.2.0",
+                "webmozart/assert": "^1.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^0.9.4",
+                "phpunit/phpunit": "^4.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "time": "2016-09-30 07:12:33"
+        },
+        {
+            "name": "phpdocumentor/type-resolver",
+            "version": "0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "b39c7a5b194f9ed7bd0dd345c751007a41862443"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/b39c7a5b194f9ed7bd0dd345c751007a41862443",
+                "reference": "b39c7a5b194f9ed7bd0dd345c751007a41862443",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5",
+                "phpdocumentor/reflection-common": "^1.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^0.9.4",
+                "phpunit/phpunit": "^5.2||^4.8.24"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "time": "2016-06-10 07:14:17"
+        },
+        {
+            "name": "phpspec/prophecy",
+            "version": "v1.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpspec/prophecy.git",
+                "reference": "58a8137754bc24b25740d4281399a4a3596058e0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/58a8137754bc24b25740d4281399a4a3596058e0",
+                "reference": "58a8137754bc24b25740d4281399a4a3596058e0",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.0.2",
+                "php": "^5.3|^7.0",
+                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2",
+                "sebastian/comparator": "^1.1",
+                "sebastian/recursion-context": "^1.0"
+            },
+            "require-dev": {
+                "phpspec/phpspec": "^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Prophecy\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Konstantin Kudryashov",
+                    "email": "ever.zet@gmail.com",
+                    "homepage": "http://everzet.com"
+                },
+                {
+                    "name": "Marcello Duarte",
+                    "email": "marcello.duarte@gmail.com"
+                }
+            ],
+            "description": "Highly opinionated mocking framework for PHP 5.3+",
+            "homepage": "https://github.com/phpspec/prophecy",
+            "keywords": [
+                "Double",
+                "Dummy",
+                "fake",
+                "mock",
+                "spy",
+                "stub"
+            ],
+            "time": "2016-06-07 08:13:47"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "5f3f7e736d6319d5f1fc402aff8b026da26709a3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/5f3f7e736d6319d5f1fc402aff8b026da26709a3",
+                "reference": "5f3f7e736d6319d5f1fc402aff8b026da26709a3",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0",
+                "phpunit/php-file-iterator": "~1.3",
+                "phpunit/php-text-template": "~1.2",
+                "phpunit/php-token-stream": "^1.4.2",
+                "sebastian/code-unit-reverse-lookup": "~1.0",
+                "sebastian/environment": "^1.3.2 || ^2.0",
+                "sebastian/version": "~1.0|~2.0"
+            },
+            "require-dev": {
+                "ext-xdebug": ">=2.1.4",
+                "phpunit/phpunit": "^5.4"
+            },
+            "suggest": {
+                "ext-dom": "*",
+                "ext-xdebug": ">=2.4.0",
+                "ext-xmlwriter": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "time": "2016-07-26 14:39:29"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "1.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
+                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "time": "2015-06-21 13:08:43"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "time": "2015-06-21 13:50:34"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "1.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/38e9124049cf1a164f1e4537caf19c99bf1eb260",
+                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4|~5"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "time": "2016-05-12 18:03:57"
+        },
+        {
+            "name": "phpunit/php-token-stream",
+            "version": "1.4.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-token-stream.git",
+                "reference": "3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da",
+                "reference": "3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Wrapper around PHP's tokenizer extension.",
+            "homepage": "https://github.com/sebastianbergmann/php-token-stream/",
+            "keywords": [
+                "tokenizer"
+            ],
+            "time": "2015-09-15 10:49:45"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "5.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "60c32c5b5e79c2248001efa2560f831da11cc2d7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/60c32c5b5e79c2248001efa2560f831da11cc2d7",
+                "reference": "60c32c5b5e79c2248001efa2560f831da11cc2d7",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "myclabs/deep-copy": "~1.3",
+                "php": "^5.6 || ^7.0",
+                "phpspec/prophecy": "^1.3.1",
+                "phpunit/php-code-coverage": "^4.0.1",
+                "phpunit/php-file-iterator": "~1.4",
+                "phpunit/php-text-template": "~1.2",
+                "phpunit/php-timer": "^1.0.6",
+                "phpunit/phpunit-mock-objects": "^3.2",
+                "sebastian/comparator": "~1.1",
+                "sebastian/diff": "~1.2",
+                "sebastian/environment": "^1.3 || ^2.0",
+                "sebastian/exporter": "~1.2",
+                "sebastian/global-state": "~1.0",
+                "sebastian/object-enumerator": "~1.0",
+                "sebastian/resource-operations": "~1.0",
+                "sebastian/version": "~1.0|~2.0",
+                "symfony/yaml": "~2.1|~3.0"
+            },
+            "conflict": {
+                "phpdocumentor/reflection-docblock": "3.0.2"
+            },
+            "require-dev": {
+                "ext-pdo": "*"
+            },
+            "suggest": {
+                "ext-xdebug": "*",
+                "phpunit/php-invoker": "~1.1"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.6.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "time": "2016-10-07 13:03:26"
+        },
+        {
+            "name": "phpunit/phpunit-mock-objects",
+            "version": "3.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
+                "reference": "238d7a2723bce689c79eeac9c7d5e1d623bb9dc2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/238d7a2723bce689c79eeac9c7d5e1d623bb9dc2",
+                "reference": "238d7a2723bce689c79eeac9c7d5e1d623bb9dc2",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.0.2",
+                "php": "^5.6 || ^7.0",
+                "phpunit/php-text-template": "^1.2",
+                "sebastian/exporter": "^1.2"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.4"
+            },
+            "suggest": {
+                "ext-soap": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Mock Object library for PHPUnit",
+            "homepage": "https://github.com/sebastianbergmann/phpunit-mock-objects/",
+            "keywords": [
+                "mock",
+                "xunit"
+            ],
+            "time": "2016-10-09 07:01:45"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "c36f5e7cfce482fde5bf8d10d41a53591e0198fe"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/c36f5e7cfce482fde5bf8d10d41a53591e0198fe",
+                "reference": "c36f5e7cfce482fde5bf8d10d41a53591e0198fe",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "time": "2016-02-13 06:45:14"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/937efb279bd37a375bcadf584dec0726f84dbf22",
+                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "sebastian/diff": "~1.2",
+                "sebastian/exporter": "~1.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "http://www.github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "time": "2015-07-26 15:48:44"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "1.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/13edfd8706462032c2f52b4b862974dd46b71c9e",
+                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.8"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff"
+            ],
+            "time": "2015-12-08 07:14:41"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "1.3.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/be2c607e43ce4c89ecd60e75c6a85c126e754aea",
+                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8 || ^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "time": "2016-08-18 05:49:44"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "1.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/42c4c2eec485ee3e159ec9884f95b431287edde4",
+                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "sebastian/recursion-context": "~1.0"
+            },
+            "require-dev": {
+                "ext-mbstring": "*",
+                "phpunit/phpunit": "~4.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "http://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "time": "2016-06-17 09:04:28"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bc37d50fea7d017d3d340f230811c9f1d7280af4",
+                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.2"
+            },
+            "suggest": {
+                "ext-uopz": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "time": "2015-10-12 03:26:01"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "d4ca2fb70344987502567bc50081c03e6192fb26"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/d4ca2fb70344987502567bc50081c03e6192fb26",
+                "reference": "d4ca2fb70344987502567bc50081c03e6192fb26",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6",
+                "sebastian/recursion-context": "~1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "time": "2016-01-28 13:25:10"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "913401df809e99e4f47b27cdd781f4a258d58791"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/913401df809e99e4f47b27cdd781f4a258d58791",
+                "reference": "913401df809e99e4f47b27cdd781f4a258d58791",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "time": "2015-11-11 19:50:13"
+        },
+        {
+            "name": "sebastian/resource-operations",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "time": "2015-07-28 20:34:47"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "c829badbd8fdf16a0bad8aa7fa7971c029f1b9c5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c829badbd8fdf16a0bad8aa7fa7971c029f1b9c5",
+                "reference": "c829badbd8fdf16a0bad8aa7fa7971c029f1b9c5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "time": "2016-02-04 12:56:52"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v3.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "368b9738d4033c8b93454cb0dbd45d305135a6d3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/368b9738d4033c8b93454cb0dbd45d305135a6d3",
+                "reference": "368b9738d4033c8b93454cb0dbd45d305135a6d3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Yaml Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-09-25 08:27:07"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/assert.git",
+                "reference": "bb2d123231c095735130cc8f6d31385a44c7b308"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/bb2d123231c095735130cc8f6d31385a44c7b308",
+                "reference": "bb2d123231c095735130cc8f6d31385a44c7b308",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3|^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6",
+                "sebastian/version": "^1.0.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "time": "2016-08-09 15:02:57"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}

--- a/example.php
+++ b/example.php
@@ -1,6 +1,5 @@
 <?php
-
-require_once __DIR__ . '/src/autoload.php';
+require_once __DIR__ . '/vendor/autoload.php';
 
 use \Erorus\DB2\Reader;
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+    colors                        = "true"
+    bootstrap                     = "vendor/autoload.php"
+    xmlns:xsi                     = "http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation = "http://schema.phpunit.de/4.4/phpunit.xsd">
+
+    <testsuites>
+        <testsuite name="erorus/db2 test suite">
+            <directory>./tests</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory>src</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -1,70 +1,78 @@
 <?php
-
 namespace Erorus\DB2;
 
+/**
+ * Read DB2 and ADB files (data tables) from World of Warcraft.
+ */
 class Reader
 {
     const EMBEDDED_STRING_FIELDS = [
-        0xEFBEADDE => [2], // tests/wdb5/EmbedStrings.db2
+        0xEFBEADDE => [2],              // tests/wdb5/EmbedStrings.db2
         0x27909DB0 => [13,14,15,16,17], // item-sparse.db2 as of 7.0.3.22522 and earlier
     ];
 
     const FIELD_TYPE_UNKNOWN = 0;
-    const FIELD_TYPE_INT = 1;
-    const FIELD_TYPE_FLOAT = 2;
-    const FIELD_TYPE_STRING = 3;
+    const FIELD_TYPE_INT     = 1;
+    const FIELD_TYPE_FLOAT   = 2;
+    const FIELD_TYPE_STRING  = 3;
 
     const DISTINCT_STRINGS_REQUIRED = 5;
 
     private $fileHandle;
     private $fileFormat = '';
-    private $fileName = '';
-    private $fileSize = 0;
+    private $fileName   = '';
+    private $fileSize   = 0;
 
-    private $headerSize = 0;
-    private $recordCount = 0;
-    private $fieldCount = 0;
-    private $recordSize = 0;
+    private $headerSize      = 0;
+    private $recordCount     = 0;
+    private $fieldCount      = 0;
+    private $recordSize      = 0;
     private $stringBlockSize = 0;
-    private $tableHash = 0;
-    private $layoutHash = 0;
-    private $timestamp = 0;
-    private $build = 0;
-    private $minId = 0;
-    private $maxId = 0;
-    private $locale = 0;
-    private $copyBlockSize = 0;
-    private $flags = 0;
-    private $idField = -1;
+    private $tableHash       = 0;
+    private $layoutHash      = 0;
+    private $timestamp       = 0;
+    private $build           = 0;
+    private $minId           = 0;
+    private $maxId           = 0;
+    private $locale          = 0;
+    private $copyBlockSize   = 0;
+    private $flags           = 0;
+    private $idField         = -1;
 
     private $hasEmbeddedStrings = false;
-    private $hasIdBlock = false;
+    private $hasIdBlock         = false;
     private $hasIdsInIndexBlock = false;
 
     private $stringBlockPos = 0;
-    private $indexBlockPos = 0;
-    private $idBlockPos = 0;
-    private $copyBlockPos = 0;
+    private $indexBlockPos  = 0;
+    private $idBlockPos     = 0;
+    private $copyBlockPos   = 0;
 
-    private $recordFormat = [];
-    
-    private $idMap = [];
+    private $idMap         = [];
+    private $recordFormat  = [];
     private $recordOffsets = null;
 
-    function __construct($db2path, $arg = null) {
+    /**
+     * @throws \Exception
+     * @param  string $db2path
+     * @param  mixed  $arg
+     */
+    function __construct($db2path, $arg = null)
+    {
         if (is_string($db2path)) {
             $this->fileHandle = @fopen($db2path, 'rb');
             if ($this->fileHandle === false) {
-                throw new \Exception("Error opening ".$db2path);
+                throw new \Exception(sprintf("Error opening %s for reading.", $db2path));
             }
             $this->fileName = strtolower(basename($db2path));
         } else {
             throw new \Exception("Must supply path to DB2 file");
         }
 
-        $fstat = fstat($this->fileHandle);
-        $this->fileSize = $fstat['size'];
+        $fstat            = fstat($this->fileHandle);
+        $this->fileSize   = $fstat['size'];
         $this->fileFormat = fread($this->fileHandle, 4);
+
         if (is_a($arg, Reader::class)) {
             switch ($this->fileFormat) {
                 case 'WCH7':
@@ -72,7 +80,9 @@ class Reader
                     $this->openWch7($arg);
                     break;
                 default:
-                    throw new \Exception("Unknown ADB format: ".$this->fileFormat);
+                    throw new \Exception(
+                        sprintf("Unknown ADB format: %s in file %s.", $this->fileFormat, $this->fileName)
+                    );
             }
         } else {
             switch ($this->fileFormat) {
@@ -81,103 +91,118 @@ class Reader
                     $this->openWdb2();
                     break;
                 case 'WDB5':
-                    if (!is_null($arg) && !is_array($arg)) {
+                    if (! is_null($arg) && !is_array($arg)) {
                         throw new \Exception("You may only pass an array of string fields when loading a DB2");
                     }
                     $this->openWdb5($arg);
                     break;
                 default:
-                    throw new \Exception("Unknown DB2 format: ".$this->fileFormat);
+                    throw new \Exception(
+                        sprintf("Unknown DB2 format: %s in file %s.", $this->fileFormat, $this->fileName)
+                    );
             }
         }
     }
 
-    function __destruct() {
+    /**
+     * Clean up resources.
+     */
+    function __destruct()
+    {
         fclose($this->fileHandle);
     }
 
-    ///// initialization
-
-    private function openWdb2() {
+    /**
+     * Initializes the reader to process a WDB2 file.
+     *
+     * @throws \Exception
+     */
+    private function openWdb2()
+    {
         fseek($this->fileHandle, 4);
-        $wdbc = $this->fileFormat == 'WDBC';
+
+        $wdbc             = $this->fileFormat == 'WDBC';
         $headerFieldCount = $wdbc ? 4 : 11;
-        $parts = array_values(unpack('V'.$headerFieldCount.'x',fread($this->fileHandle, 4 * $headerFieldCount)));
+        $parts            = array_values(unpack('V'.$headerFieldCount.'x',fread($this->fileHandle, 4 * $headerFieldCount)));
 
-        $this->recordCount      = $parts[0];
-        $this->fieldCount       = $parts[1];
-        $this->recordSize       = $parts[2];
-        $this->stringBlockSize  = $parts[3];
-        $this->tableHash        = $wdbc ? 0 : $parts[4];
-        $this->build            = $wdbc ? 0 : $parts[5];
-        $this->timestamp        = $wdbc ? 0 : $parts[6];
-        $this->minId            = $wdbc ? 0 : $parts[7];
-        $this->maxId            = $wdbc ? 0 : $parts[8];
-        $this->locale           = $wdbc ? 0 : $parts[9];
-        $this->copyBlockSize    = $wdbc ? 0 : $parts[10];
-
-        $this->headerSize = 4 * ($headerFieldCount + 1);
-
+        $this->recordCount        = $parts[0];
+        $this->fieldCount         = $parts[1];
+        $this->recordSize         = $parts[2];
+        $this->stringBlockSize    = $parts[3];
+        $this->tableHash          = $wdbc ? 0 : $parts[4];
+        $this->build              = $wdbc ? 0 : $parts[5];
+        $this->timestamp          = $wdbc ? 0 : $parts[6];
+        $this->minId              = $wdbc ? 0 : $parts[7];
+        $this->maxId              = $wdbc ? 0 : $parts[8];
+        $this->locale             = $wdbc ? 0 : $parts[9];
+        $this->copyBlockSize      = $wdbc ? 0 : $parts[10];
+        $this->headerSize         = 4 * ($headerFieldCount + 1);
         $this->hasEmbeddedStrings = false;
-
-        $this->hasIdBlock = $this->maxId > 0;
-        $this->idBlockPos = $this->headerSize;
+        $this->hasIdBlock         = $this->maxId > 0;
+        $this->idBlockPos         = $this->headerSize;
 
         if ($this->hasIdBlock) {
             $this->headerSize += 6 * ($this->maxId - $this->minId + 1);
         }
 
         $this->stringBlockPos = $this->headerSize + ($this->recordCount * $this->recordSize);
-        $this->copyBlockPos = $this->stringBlockPos + $this->stringBlockSize;
+        $this->copyBlockPos   = $this->stringBlockPos + $this->stringBlockSize;
 
         $eof = $this->copyBlockPos + $this->copyBlockSize;
         if ($eof != $this->fileSize) {
-            throw new \Exception("Expected size: $eof, actual size: ".$this->fileSize);
+            throw new \Exception(sprintf("Expected size: %d, actual size: %d.", $eof, $this->fileSize));
         }
 
         $this->recordFormat = [];
         for ($fieldId = 0; $fieldId < $this->fieldCount; $fieldId++) {
             $this->recordFormat[$fieldId] = [
-                'bitShift' => 0,
-                'offset' => $fieldId * 4,
+                'bitShift'    => 0,
+                'offset'      => $fieldId * 4,
                 'valueLength' => 4,
-                'valueCount' => 1,
-                'type' => static::FIELD_TYPE_UNKNOWN,
-                'signed' => true,
+                'valueCount'  => 1,
+                'type'        => static::FIELD_TYPE_UNKNOWN,
+                'signed'      => true,
             ] ;
         }
 
         $this->idField = 0;
-
         $this->populateIdMap();
         $this->guessFieldTypes();
     }
 
-    private function openWdb5($stringFields) {
+    /**
+     * Initializes the reader to process a WDB5 file.
+     *
+     * @throws \Exception
+     * @param  string[] $stringFields
+     */
+    private function openWdb5($stringFields)
+    {
         fseek($this->fileHandle, 4);
         $parts = array_values(unpack('V10x/v2y',fread($this->fileHandle, 4 * 11)));
 
-        $this->recordCount      = $parts[0];
-        $this->fieldCount       = $parts[1];
-        $this->recordSize       = $parts[2];
-        $this->stringBlockSize  = $parts[3];
-        $this->tableHash        = $parts[4];
-        $this->layoutHash       = $parts[5];
-        $this->minId            = $parts[6];
-        $this->maxId            = $parts[7];
-        $this->locale           = $parts[8];
-        $this->copyBlockSize    = $parts[9];
-        $this->flags            = $parts[10];
-        $this->idField          = $parts[11];
-
-        $this->headerSize = 48 + $this->fieldCount * 4;
-
+        $this->recordCount        = $parts[0];
+        $this->fieldCount         = $parts[1];
+        $this->recordSize         = $parts[2];
+        $this->stringBlockSize    = $parts[3];
+        $this->tableHash          = $parts[4];
+        $this->layoutHash         = $parts[5];
+        $this->minId              = $parts[6];
+        $this->maxId              = $parts[7];
+        $this->locale             = $parts[8];
+        $this->copyBlockSize      = $parts[9];
+        $this->flags              = $parts[10];
+        $this->idField            = $parts[11];
+        $this->headerSize         = 48 + $this->fieldCount * 4;
         $this->hasEmbeddedStrings = ($this->flags & 1) > 0;
-        $this->hasIdBlock = ($this->flags & 4) > 0;
+        $this->hasIdBlock         = ($this->flags & 4) > 0;
 
         if ($this->hasEmbeddedStrings) {
-            if (!$this->hasIdBlock) {
-                throw new \Exception("File has embedded strings and no ID block, which was not expected, aborting");
+            if (! $this->hasIdBlock) {
+                throw new \Exception(sprintf(
+                    "%s has embedded strings and no ID block, which was not expected, aborting",
+                    $this->fileName
+                ));
             }
             $this->stringBlockPos = $this->fileSize - $this->copyBlockSize - ($this->recordCount * 4);
             $this->indexBlockPos = $this->stringBlockSize;
@@ -187,30 +212,41 @@ class Reader
                 if (array_key_exists($this->layoutHash, static::EMBEDDED_STRING_FIELDS)) {
                     $stringFields = static::EMBEDDED_STRING_FIELDS[$this->layoutHash];
                 } else {
-                    throw new \Exception($this->fileName." has embedded strings, but string fields were not supplied during instantiation");
+                    throw new \Exception(sprintf(
+                        "%s has embedded strings, but string fields were not supplied during instantiation",
+                        $this->fileName
+                    ));
                 }
             }
         } else {
             $this->stringBlockPos = $this->headerSize + ($this->recordCount * $this->recordSize);
         }
-        $this->idBlockPos = $this->stringBlockPos + $this->stringBlockSize;
 
+        $this->idBlockPos   = $this->stringBlockPos + $this->stringBlockSize;
         $this->copyBlockPos = $this->idBlockPos + ($this->hasIdBlock ? $this->recordCount * 4 : 0);
+        $eof                = $this->copyBlockPos + $this->copyBlockSize;
 
-        $eof = $this->copyBlockPos + $this->copyBlockSize;
         if ($eof != $this->fileSize) {
-            throw new \Exception("Expected size: $eof, actual size: ".$this->fileSize);
+            throw new \Exception(sprintf("Expected size: %d, actual size: %d", $eof, $this->fileSize));
         }
 
         fseek($this->fileHandle, 48);
         $this->recordFormat = [];
+
         for ($fieldId = 0; $fieldId < $this->fieldCount; $fieldId++) {
-            $this->recordFormat[$fieldId] = unpack('vbitShift/voffset', fread($this->fileHandle, 4));
+            $this->recordFormat[$fieldId]                = unpack('vbitShift/voffset', fread($this->fileHandle, 4));
             $this->recordFormat[$fieldId]['valueLength'] = ceil((32 - $this->recordFormat[$fieldId]['bitShift']) / 8);
-            $this->recordFormat[$fieldId]['type'] = ($this->recordFormat[$fieldId]['valueLength'] != 4) ? static::FIELD_TYPE_INT : static::FIELD_TYPE_UNKNOWN;
-            if ($this->hasEmbeddedStrings && $this->recordFormat[$fieldId]['type'] == static::FIELD_TYPE_UNKNOWN && in_array($fieldId, $stringFields)) {
+            $this->recordFormat[$fieldId]['type']        = ($this->recordFormat[$fieldId]['valueLength'] != 4)
+                ? static::FIELD_TYPE_INT
+                : static::FIELD_TYPE_UNKNOWN;
+
+            if ($this->hasEmbeddedStrings &&
+                $this->recordFormat[$fieldId]['type'] == static::FIELD_TYPE_UNKNOWN &&
+                in_array($fieldId, $stringFields))
+            {
                 $this->recordFormat[$fieldId]['type'] = static::FIELD_TYPE_STRING;
             }
+
             $this->recordFormat[$fieldId]['signed'] = false;
             if ($fieldId > 0) {
                 $this->recordFormat[$fieldId - 1]['valueCount'] =
@@ -223,16 +259,21 @@ class Reader
         $this->recordFormat[$fieldId]['valueCount'] = max(1, floor($remainingBytes / $this->recordFormat[$fieldId]['valueLength']));
         if ($this->recordFormat[$fieldId]['valueCount'] > 1 &&    // we're guessing the last column is an array
             (($this->recordSize % 4 == 0 && $remainingBytes <= 4) // records may be padded to word length and the last field size <= word size
-            || ($this->idField == $fieldId))) {                   // or the reported ID field is the last field
+            || ($this->idField == $fieldId))                      // or the reported ID field is the last field
+        ) {
             $this->recordFormat[$fieldId]['valueCount'] = 1;      // assume the last field is scalar, and the remaining bytes are just padding
         }
 
-        if (!$this->hasIdBlock) {
+        if (! $this->hasIdBlock) {
             if ($this->idField >= $this->fieldCount) {
-                throw new \Exception("Expected ID field " . $this->idField . " does not exist. Only found " . $this->fieldCount . " fields.");
+                throw new \Exception(sprintf('ID field %s in file %s is out of bounds: 0-%d', $this->idField, $this->fileName, $this->fieldCount));
             }
             if ($this->recordFormat[$this->idField]['valueCount'] != 1) {
-                throw new \Exception("Expected ID field " . $this->idField . " reportedly has " . $this->recordFormat[$this->idField]['valueCount'] . " values per row");
+                throw new \Exception(sprintf(
+                    "Expected ID field %d reportedly has %d values per row.",
+                    $this->idField,
+                    $this->recordFormat[$this->idField]['valueCount']
+                ));
             }
         }
 
@@ -240,7 +281,8 @@ class Reader
 
         if ($this->hasEmbeddedStrings) {
             for ($fieldId = 0; $fieldId < $this->fieldCount; $fieldId++) {
-                unset($this->recordFormat[$fieldId]['offset']); // just to make sure we don't use them later, because they're meaningless now
+                // just to make sure we don't use them later, because they're meaningless now
+                unset($this->recordFormat[$fieldId]['offset']);
             }
             $this->populateRecordOffsets();
         }
@@ -248,7 +290,14 @@ class Reader
         $this->guessFieldTypes();
     }
 
-    private function openWch7(Reader $sourceReader) {
+    /**
+     * Initializes the reader to process a WCH7 file.
+     *
+     * @throws \Exception
+     * @param  Reader $sourceReader
+     */
+    private function openWch7(Reader $sourceReader)
+    {
         fseek($this->fileHandle, 4);
         $parts = array_values(unpack('V12x',fread($this->fileHandle, 4 * 12)));
 
@@ -275,33 +324,47 @@ class Reader
 
         foreach (['tableHash', 'layoutHash', 'fieldCount'] as $headerField) {
             if ($this->$headerField != $sourceReader->$headerField) {
-                throw new \Exception("$headerField of {$this->fileName} ({$this->$headerField}) does not match $headerField of {$sourceReader->fileName} ({$sourceReader->$headerField})");
+                throw new \Exception(sprintf(
+                    "%s of %s (%s) does not match %s of %s (%s)",
+                    $headerField,
+                    $this->fileName,
+                    $this->$headerField,
+                    $headerField,
+                    $sourceReader->fileName,
+                    $sourceReader->$headerField
+                ));
             }
         }
         if (($sourceReader->locale & $this->locale) != $this->locale) {
             $headerField = 'locale';
-            throw new \Exception("$headerField of {$this->fileName} ({$this->$headerField}) does not match $headerField of {$sourceReader->fileName} ({$sourceReader->$headerField})");
+            throw new \Exception(sprintf(
+                "%s of %s (%s) does not match %s of %s (%s)",
+                $headerField,
+                $this->fileName,
+                $this->$headerField,
+                $headerField,
+                $sourceReader->fileName,
+                $sourceReader->$headerField
+            ));
         }
 
         if ($this->hasEmbeddedStrings) {
             // this could get messy
             $this->hasIdsInIndexBlock = true;
-            $this->hasIdBlock = !$this->hasIdsInIndexBlock;
-
-            $this->indexBlockPos = $this->headerSize + $this->stringBlockSize; // stringBlockSize is really just the offset after the header to the index block
-
-            $this->stringBlockPos = $this->idBlockPos = $this->fileSize;
-            $this->stringBlockSize = 0;
+            $this->hasIdBlock         = !$this->hasIdsInIndexBlock;
+            $this->indexBlockPos      = $this->headerSize + $this->stringBlockSize; // stringBlockSize is really just the offset after the header to the index block
+            $this->stringBlockPos     = $this->idBlockPos = $this->fileSize;
+            $this->stringBlockSize    = 0;
         } else {
             $this->stringBlockPos = $this->headerSize + ($this->recordCount * $this->recordSize);
-            $this->idBlockPos = $unkTableSize * 4 + $this->stringBlockPos + $this->stringBlockSize;
+            $this->idBlockPos     = $unkTableSize * 4 + $this->stringBlockPos + $this->stringBlockSize;
         }
 
         $this->copyBlockPos = $this->idBlockPos + ($this->hasIdBlock ? $this->recordCount * 4 : 0);
+        $eof                = $this->copyBlockPos + $this->copyBlockSize;
 
-        $eof = $this->copyBlockPos + $this->copyBlockSize;
         if ($eof != $this->fileSize) {
-            throw new \Exception("Expected size: $eof, actual size: ".$this->fileSize);
+            throw new \Exception(sprintf("Expected size: %d, actual size: %d.", $eof, $this->fileSize));
         }
 
         $this->recordFormat = $sourceReader->recordFormat;
@@ -313,19 +376,24 @@ class Reader
         }
     }
 
-    private function guessFieldTypes() {
+    /**
+     * @throws \Exception
+     */
+    private function guessFieldTypes()
+    {
         foreach ($this->recordFormat as $fieldId => &$format) {
             if ($format['type'] != static::FIELD_TYPE_UNKNOWN || $format['valueLength'] != 4) {
                 continue;
             }
 
-            $couldBeFloat = true;
-            $couldBeString = !$this->hasEmbeddedStrings;
-            $recordOffset = 0;
+            $couldBeFloat   = true;
+            $couldBeString  = !$this->hasEmbeddedStrings;
+            $recordOffset   = 0;
             $distinctValues = [];
+
             while (($couldBeString || $couldBeFloat) && $recordOffset < $this->recordCount) {
                 $data = $this->getRawRecord($recordOffset);
-                if (!$this->hasEmbeddedStrings) {
+                if (! $this->hasEmbeddedStrings) {
                     $byteOffset = $format['offset'];
                 } else {
                     // format offsets mean nothing
@@ -335,7 +403,12 @@ class Reader
                             for ($offsetFieldValueId = 0; $offsetFieldValueId < $this->recordFormat[$offsetFieldId]['valueCount']; $offsetFieldValueId++) {
                                 $byteOffset = strpos($data, "\x00", $byteOffset);
                                 if ($byteOffset === false) {
-                                    throw new \Exception("Could not find end of embedded string $offsetFieldId x $offsetFieldValueId in record $recordOffset");
+                                    throw new \Exception(sprintf(
+                                        "Could not find end of embedded string %d x %d in record %d",
+                                        $offsetFieldId,
+                                        $offsetFieldValueId,
+                                        $recordOffset
+                                    ));
                                 }
                                 $byteOffset++; // skip nul byte
                             }
@@ -344,7 +417,8 @@ class Reader
                         }
                     }
                 }
-                $data = substr($data, $byteOffset, $format['valueLength'] * $format['valueCount']);
+
+                $data   = substr($data, $byteOffset, $format['valueLength'] * $format['valueCount']);
                 $values = unpack('V*', $data);
                 foreach ($values as $value) {
                     if ($value == 0) {
@@ -380,11 +454,11 @@ class Reader
                 $recordOffset++;
             }
 
-            if ($couldBeString && ($this->recordCount < static::DISTINCT_STRINGS_REQUIRED * 2 || count($distinctValues) >= static::DISTINCT_STRINGS_REQUIRED)) {
-                $format['type'] = static::FIELD_TYPE_STRING;
+            if ($couldBeString &&($this->recordCount < static::DISTINCT_STRINGS_REQUIRED * 2 || count($distinctValues) >= static::DISTINCT_STRINGS_REQUIRED)) {
+                $format['type']   = static::FIELD_TYPE_STRING;
                 $format['signed'] = false;
             } elseif ($couldBeFloat) {
-                $format['type'] = static::FIELD_TYPE_FLOAT;
+                $format['type']   = static::FIELD_TYPE_FLOAT;
                 $format['signed'] = true;
             } else {
                 $format['type'] = static::FIELD_TYPE_INT;
@@ -392,10 +466,14 @@ class Reader
         }
         unset($format);
     }
-    
-    private function populateIdMap() {
+
+    /**
+     * @throws \Exception
+     */
+    private function populateIdMap()
+    {
         $this->idMap = [];
-        if (!$this->hasIdBlock) {
+        if (! $this->hasIdBlock) {
             $this->recordFormat[$this->idField]['signed'] = false; // in case it's a 32-bit int
             $fieldFormat = $this->recordFormat[$this->idField];
             for ($x = 0; $x < $this->recordCount; $x++) {
@@ -423,8 +501,8 @@ class Reader
             $entryCount = floor($this->copyBlockSize / 8);
             for ($x = 0; $x < $entryCount; $x++) {
                 list($newId, $existingId) = array_values(unpack('V*', fread($this->fileHandle, 8)));
-                if (!isset($this->idMap[$existingId])) {
-                    throw new \Exception("Copy block referenced ID $existingId which does not exist");
+                if (! isset($this->idMap[$existingId])) {
+                    throw new \Exception(sprintf("Copy block referenced ID %d which does not exist", $existingId));
                 }
                 $this->idMap[$newId] = $this->idMap[$existingId];
             }
@@ -432,12 +510,15 @@ class Reader
         }
     }
 
-    private function populateRecordOffsets() {
-        // only required when hasEmbeddedStrings,
-        // since it has the index block to map back into the data block
-
+    /**
+     * Populates record offsets.
+     * Only required when 'hasEmbeddedStrings' is true, since it has the index block to map back into the data block.
+     */
+    private function populateRecordOffsets()
+    {
         fseek($this->fileHandle, $this->indexBlockPos);
         $this->recordOffsets = [];
+
         if ($this->hasIdsInIndexBlock) {
             $this->idMap = [];
             $lowerBound = 0;
@@ -447,11 +528,12 @@ class Reader
             $upperBound = $this->maxId;
         }
         $seenBefore = [];
+
         for ($x = $lowerBound; $x <= $upperBound; $x++) {
             if ($this->hasIdsInIndexBlock) {
-                $bytes = fread($this->fileHandle, 10);
+                $bytes   = fread($this->fileHandle, 10);
                 $pointer = unpack('Vid/Vpos/vsize', $bytes);
-                $bytes = substr($bytes, 4); // crop off ID in front to match other case
+                $bytes   = substr($bytes, 4); // crop off ID in front to match other case
                 $this->idMap[$pointer['id']] = $x;
             } else {
                 $bytes = fread($this->fileHandle, 6);
@@ -459,10 +541,10 @@ class Reader
                 $pointer['id'] = $x;
             }
             if ($pointer['size'] > 0) {
-                if (!isset($seenBefore[$pointer['pos']])) {
+                if (! isset($seenBefore[$pointer['pos']])) {
                     $seenBefore[$pointer['pos']] = [];
                 }
-                if (!isset($this->idMap[$pointer['id']])) {
+                if (! isset($this->idMap[$pointer['id']])) {
                     //echo "Found {$pointer['pos']} x {$pointer['size']} in index block for $pointer['id'] which isn't in id block\n";
                     foreach ($seenBefore[$pointer['pos']] as $anotherId) {
                         if (isset($this->idMap[$anotherId])) {
@@ -474,7 +556,7 @@ class Reader
                 if (isset($this->idMap[$pointer['id']])) {
                     $this->recordOffsets[$this->idMap[$pointer['id']]] = $bytes;
                     foreach ($seenBefore[$pointer['pos']] as $anotherId) {
-                        if (!isset($this->idMap[$anotherId])) {
+                        if (! isset($this->idMap[$anotherId])) {
                             //echo "Mapping previously seen $anotherId to match $pointer['id']\n";
                             $this->idMap[$anotherId] = $this->idMap[$pointer['id']];
                         }
@@ -487,14 +569,18 @@ class Reader
         ksort($this->idMap);
     }
 
-    // general purpose for internal use
-
-    private function getRawRecord($recordOffset) {
-        if (!is_null($this->recordOffsets)) {
+    /**
+     * @throws \Exception
+     * @param  int $recordOffset
+     * @return string
+     */
+    private function getRawRecord($recordOffset)
+    {
+        if (! is_null($this->recordOffsets)) {
             $pointer = unpack('Vpos/vsize', $this->recordOffsets[$recordOffset]);
             if ($pointer['size'] == 0) {
                 // @codeCoverageIgnoreStart
-                throw new \Exception("Requested record offset $recordOffset which is empty");
+                throw new \Exception(sprintf("Requested record offset %d which is empty", $recordOffset));
                 // @codeCoverageIgnoreEnd
             }
             fseek($this->fileHandle, $pointer['pos']);
@@ -503,32 +589,55 @@ class Reader
             fseek($this->fileHandle, $this->headerSize + $recordOffset * $this->recordSize);
             $data = fread($this->fileHandle, $this->recordSize);
         }
+
         return $data;
     }
 
-    private function getString($stringBlockOffset) {
+    /**
+     * @throws \Exception
+     * @param  int $stringBlockOffset
+     * @return string
+     */
+    private function getString($stringBlockOffset)
+    {
         if ($stringBlockOffset >= $this->stringBlockSize) {
             // @codeCoverageIgnoreStart
-            throw new \Exception("Asked to get string from $stringBlockOffset, string block size is only ".$this->stringBlockSize);
+            throw new \Exception(sprintf(
+                "Asked to get string from %d, string block size is only %d",
+                $stringBlockOffset,
+                $this->stringBlockSize)
+            );
             // @codeCoverageIgnoreEnd
         }
         $maxLength = $this->stringBlockSize - $stringBlockOffset;
-
         fseek($this->fileHandle, $this->stringBlockPos + $stringBlockOffset);
+
         return stream_get_line($this->fileHandle, $maxLength, "\x00");
     }
 
-    private function getRecordByOffset($recordOffset) {
+    /**
+     * Returns a record by the given offset.
+     *
+     * @throws \Exception
+     * @param  int $recordOffset
+     * @return array
+     */
+    private function getRecordByOffset($recordOffset)
+    {
         if ($recordOffset < 0 || $recordOffset >= $this->recordCount) {
             // @codeCoverageIgnoreStart
-            throw new \Exception("Requested record offset $recordOffset out of bounds: 0-".$this->recordCount);
+            throw new \Exception(sprintf(
+                "Requested record offset %d out of bounds: 0-%d",
+                $recordOffset,
+                $this->recordCount
+            ));
             // @codeCoverageIgnoreEnd
         }
 
-        $record = $this->getRawRecord($recordOffset);
-
+        $record        = $this->getRawRecord($recordOffset);
         $runningOffset = 0;
-        $row = [];
+        $row           = [];
+
         for ($fieldId = 0; $fieldId < $this->fieldCount; $fieldId++) {
             $field = [];
             $format = $this->recordFormat[$fieldId];
@@ -581,31 +690,61 @@ class Reader
         return $row;
     }
 
-    // standard usage
-
-    public function getFieldCount() {
+    /**
+     * Returns the total amount of fields.
+     *
+     * @return int
+     */
+    public function getFieldCount()
+    {
         return $this->fieldCount;
     }
 
-    public function getRecord($id) {
-        if (!isset($this->idMap[$id])) {
+    /**
+     * Returns a record by the given ID or NULL if no such record exists.
+     *
+     * @param  int $id
+     * @return array|null
+     */
+    public function getRecord($id)
+    {
+        if (! isset($this->idMap[$id])) {
             return null;
         }
-        
+
         return $this->getRecordByOffset($this->idMap[$id]);
     }
 
-    public function getIds() {
+    /**
+     * Returns an array of ID's.
+     *
+     * @return int[]
+     */
+    public function getIds()
+    {
         return array_keys($this->idMap);
     }
 
-    public function generateRecords() {
+    /**
+     * Returns all records.
+     *
+     * @return \Generator
+     */
+    public function generateRecords()
+    {
         foreach ($this->idMap as $id => $offset) {
             yield $id => $this->getRecordByOffset($offset);
         }
     }
 
-    public function getFieldTypes($byName = true) {
+    /**
+     * Returns all field types - by name if possible.
+     *
+     * @param  bool $byName (default: true)
+     * @return array
+     */
+    public function getFieldTypes($byName = true)
+    {
         $fieldTypes = [];
         foreach ($this->recordFormat as $fieldId => $format) {
             if ($byName && isset($format['name'])) {
@@ -613,21 +752,36 @@ class Reader
             }
             $fieldTypes[$fieldId] = $format['type'];
         }
+
         return $fieldTypes;
     }
 
-    public function loadAdb($adbPath) {
+    /**
+     * Returns a new Reader instance for ADB files with this one as its parent.
+     *
+     * @param  string $adbPath
+     * @return Reader
+     */
+    public function loadAdb($adbPath)
+    {
         return new Reader($adbPath, $this);
     }
 
-    // user preferences
-
-    public function setFieldsSigned(Array $fields) {
+    /**
+     * Marks the given fields as signed.
+     * Accepts an associative array indexed by field ID and a boolean determining whether to mark a field as 'signed'.
+     *
+     * @throws \Exception
+     * @param  bool[] $fields
+     * @return array
+     */
+    public function setFieldsSigned(array $fields)
+    {
         foreach ($fields as $fieldId => $isSigned) {
             if ($fieldId < 0 || $fieldId >= $this->fieldCount) {
-                throw new \Exception("Field ID $fieldId out of bounds: 0-".($this->fieldCount - 1));
+                throw new \Exception(sprintf("Field ID %d out of bounds: 0-%d", $fieldId, ($this->fieldCount - 1)));
             }
-            if (!$this->hasIdBlock && $this->idField == $fieldId) {
+            if (! $this->hasIdBlock && $this->idField == $fieldId) {
                 continue;
             }
             if ($this->recordFormat[$fieldId]['type'] != static::FIELD_TYPE_INT) {
@@ -640,21 +794,31 @@ class Reader
         foreach ($this->recordFormat as $fieldId => $format) {
             $signedFields[$fieldId] = $format['signed'];
         }
+
         return $signedFields;
     }
 
-    public function setFieldNames(Array $names) {
+    /**
+     * Sets the names of fields by ID.
+     * Accepts an associative array of field names indexed by field ID.
+     *
+     * @throws \Exception
+     * @param  string[] $names
+     * @return array
+     */
+    public function setFieldNames(array $names)
+    {
         foreach ($names as $fieldId => $name) {
-            if (!is_numeric($fieldId)) {
-                throw new \Exception("Field ID $fieldId must be numeric");
+            if (! is_numeric($fieldId)) {
+                throw new \Exception(sprintf("Field ID %s must be numeric", $fieldId));
             }
             if (is_numeric($name)) {
-                throw new \Exception("Field $fieldId Name ($name) must NOT be numeric");
+                throw new \Exception(sprintf("Field %d Name (%d) must NOT be numeric", $fieldId, $name));
             }
             if ($fieldId < 0 || $fieldId >= $this->fieldCount) {
-                throw new \Exception("Field ID $fieldId out of bounds: 0-".($this->fieldCount - 1));
+                throw new \Exception(sprintf("Field ID %d out of bounds: 0-%d", $fieldId, ($this->fieldCount - 1)));
             }
-            if (!$name) {
+            if (! $name) {
                 unset($this->recordFormat[$fieldId]['name']);
             } else {
                 $this->recordFormat[$fieldId]['name'] = $name;
@@ -667,15 +831,20 @@ class Reader
                 $namedFields[$fieldId] = $format['name'];
             }
         }
+
         return $namedFields;
     }
 
-    // static utils
-
-    public static function flattenRecord(Array $record) {
+    /**
+     * @param  array $record
+     * @return array
+     */
+    public static function flattenRecord(array $record)
+    {
         $result = [];
+
         foreach ($record as $k => $v) {
-            if (!is_array($v)) {
+            if (! is_array($v)) {
                 $result[$k] = $v;
                 continue;
             }
@@ -684,6 +853,7 @@ class Reader
                 $result["$k-" . $idx++] = $vv;
             }
         }
+
         return $result;
     }
 }

--- a/src/autoload.php
+++ b/src/autoload.php
@@ -1,9 +1,7 @@
 <?php
-
-spl_autoload_register(function($class) {
-    $path = __DIR__.'/'.str_replace('\\',DIRECTORY_SEPARATOR, $class).'.php';
-    if (file_exists($path)) {
-        include $path;
-    }
-});
-
+// This file is deprecated and no longer used.
+// It remains here for backward compatibility for those who still use this.
+@trigger_error(
+    sprintf('"%"s is deprecated and no longer used. You no longer need to include this file manually.', __FILE__),
+    E_USER_DEPRECATED
+);

--- a/tests/ReaderTest.php
+++ b/tests/ReaderTest.php
@@ -1,43 +1,36 @@
 <?php
-
 use Erorus\DB2\Reader;
 
-class ReaderTest extends phpunit\framework\TestCase
+class ReaderTest extends \PHPUnit\Framework\TestCase
 {
     const WDB5_PATH = __DIR__.'/wdb5';
 
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Must supply path to DB2 file
+     */
     public function testInvalidDB2Param()
     {
-        try {
-            $reader = new Reader(0);
-            $this->fail("Did not throw exception on invalid db2 param");
-        } catch (Exception $e) {
-            $this->assertEquals("Must supply path to DB2 file", $e->getMessage());
-        }
+        new Reader(0);
     }
 
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Error opening /dev/null/notfound.db2 for reading.
+     */
     public function testMissingFile()
     {
-        $db2path = '/dev/null/notfound.db2';
-
-        try {
-            $reader = new Reader($db2path);
-            $this->fail("Did not throw exception on missing file");
-        } catch (Exception $e) {
-            $this->assertEquals("Error opening $db2path", $e->getMessage());
-        }
+        new Reader('/dev/null/notfound.db2');
     }
 
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Unknown DB2 format: XXXX in file badformat.db2.
+     */
     public function testInvalidFileFormat()
     {
-        $format = substr(file_get_contents(static::WDB5_PATH.'/BadFormat.db2'), 0, 4);
-
-        try {
-            $reader = new Reader(static::WDB5_PATH.'/BadFormat.db2');
-            $this->fail("Did not throw exception on unknown file format");
-        } catch (Exception $e) {
-            $this->assertEquals("Unknown DB2 format: $format", $e->getMessage());
-        }
+        $file = static::WDB5_PATH.'/BadFormat.db2';
+        new Reader($file);
     }
 
     public function testWDB5FormatLoad()
@@ -46,24 +39,22 @@ class ReaderTest extends phpunit\framework\TestCase
         $this->assertEquals(1, $reader->getFieldCount());
     }
 
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Expected size: 59, actual size: 68
+     */
     public function testFileTooLong()
     {
-        try {
-            $reader = new Reader(static::WDB5_PATH.'/TooLong.db2');
-            $this->fail("Did not notice db2 file was too long");
-        } catch (Exception $e) {
-            $this->assertRegExp('/^Expected size: \d+, actual size: '.filesize(static::WDB5_PATH.'/TooLong.db2').'$/', $e->getMessage());
-        }
+       new Reader(static::WDB5_PATH.'/TooLong.db2');
     }
 
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Expected size: 374, actual size: 64
+     */
     public function testFileTooShort()
     {
-        try {
-            $reader = new Reader(static::WDB5_PATH.'/TooShort.db2');
-            $this->fail("Did not notice db2 file was too short");
-        } catch (Exception $e) {
-            $this->assertRegExp('/^Expected size: \d+, actual size: '.filesize(static::WDB5_PATH.'/TooShort.db2').'$/', $e->getMessage());
-        }
+        new Reader(static::WDB5_PATH.'/TooShort.db2');
     }
 
     public function testLoadRecordFromIDBlock()
@@ -90,16 +81,14 @@ class ReaderTest extends phpunit\framework\TestCase
         $this->assertEquals(200, $rec[0]);
     }
 
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Field ID 1 out of bounds: 0-0
+     */
     public function testSignedFieldOutOfBounds()
     {
         $reader = new Reader(static::WDB5_PATH . '/IdBlock.db2');
-
-        try {
-            $reader->setFieldsSigned([false, true]);
-            $this->fail("Did not flag field 1 as out of bounds");
-        } catch (Exception $e) {
-            $this->assertEquals("Field ID 1 out of bounds: 0-0", $e->getMessage());
-        }
+        $reader->setFieldsSigned([false, true]);
     }
 
     public function testFieldNames()
@@ -119,40 +108,34 @@ class ReaderTest extends phpunit\framework\TestCase
         $this->assertEquals(200, $rec[0]);
     }
 
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Field ID abc must be numeric
+     */
     public function testFieldNameInvalidIndex()
     {
         $reader = new Reader(static::WDB5_PATH . '/IdBlock.db2');
-
-        try {
-            $reader->setFieldNames(['abc' => 'abc']);
-            $this->fail("Did not flag field 'abc' as invalid");
-        } catch (Exception $e) {
-            $this->assertEquals("Field ID abc must be numeric", $e->getMessage());
-        }
+        $reader->setFieldNames(['abc' => 'abc']);
     }
 
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Field 0 Name (99) must NOT be numeric
+     */
     public function testFieldNameNumeric()
     {
         $reader = new Reader(static::WDB5_PATH . '/IdBlock.db2');
-
-        try {
-            $reader->setFieldNames([99]);
-            $this->fail("Did not flag field name 99 as numeric");
-        } catch (Exception $e) {
-            $this->assertEquals("Field 0 Name (99) must NOT be numeric", $e->getMessage());
-        }
+        $reader->setFieldNames([99]);
     }
 
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Field ID 99 out of bounds: 0-0
+     */
     public function testFieldOutOfBounds()
     {
         $reader = new Reader(static::WDB5_PATH . '/IdBlock.db2');
-
-        try {
-            $reader->setFieldNames([99=>'test']);
-            $this->fail("Did not flag field 99 as out of bounds");
-        } catch (Exception $e) {
-            $this->assertEquals("Field ID 99 out of bounds: 0-0", $e->getMessage());
-        }
+        $reader->setFieldNames([99=>'test']);
     }
 
     public function testUnknownRecordID()
@@ -199,14 +182,13 @@ class ReaderTest extends phpunit\framework\TestCase
         }
     }
 
+    /**
+     * @expectedException \TypeError
+     * @expectedExceptionMessage must be of the type array, string given
+     */
     public function testFlattenString()
     {
-        try {
-            $result = Reader::flattenRecord("abc");
-            $this->fail("Returned something when trying to flatten string abc");
-        } catch (TypeError $e) {
-            $this->assertFalse(strpos($e->getMessage(), 'must be of the type array, string given') === false);
-        }
+        Reader::flattenRecord("abc");
     }
 
     public function testFlattenNormalRecord()
@@ -372,14 +354,13 @@ class ReaderTest extends phpunit\framework\TestCase
         $this->assertEquals(200,        $rec[6]);
     }
 
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage embedstringswithoutidblock.db2 has embedded strings and no ID block, which was not expected, aborting
+     */
     public function testEmbedStringsWithoutIdBlock()
     {
-        try {
-            $reader = new Reader(static::WDB5_PATH . '/EmbedStringsWithoutIdBlock.db2');
-            $this->fail("No exception raised with file with embedded strings without id block");
-        } catch (Exception $e) {
-            $this->assertEquals("File has embedded strings and no ID block, which was not expected, aborting", $e->getMessage());
-        }
+        new Reader(static::WDB5_PATH . '/EmbedStringsWithoutIdBlock.db2');
     }
 
     public function testEmbedStrings()
@@ -403,14 +384,13 @@ class ReaderTest extends phpunit\framework\TestCase
         $this->assertEquals($rec, $reader->getRecord(102)); // 102 just points to 103's data in index block
     }
 
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage embedstringsunknownhash.db2 has embedded strings, but string fields were not supplied during instantiation
+     */
     public function testUnknownEmbedStrings()
     {
-        try {
-            $reader = new Reader(static::WDB5_PATH . '/EmbedStringsUnknownHash.db2');
-            $this->fail("No exception raised with file with unknown embedded strings file");
-        } catch (Exception $e) {
-            $this->assertEquals("embedstringsunknownhash.db2 has embedded strings, but string fields were not supplied during instantiation", $e->getMessage());
-        }
+        new Reader(static::WDB5_PATH . '/EmbedStringsUnknownHash.db2');
     }
 
     public function testKnownEmbedStrings()
@@ -419,54 +399,49 @@ class ReaderTest extends phpunit\framework\TestCase
         $this->assertEquals(4, $reader->getFieldCount());
     }
 
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage ID field 88 in file badidfield.db2 is out of bounds: 0-7
+     */
     public function testBadIdField()
     {
-        try {
-            $reader = new Reader(static::WDB5_PATH . '/BadIdField.db2');
-            $this->fail("No exception raised with bad ID field in header");
-        } catch (Exception $e) {
-            $this->assertEquals("Expected ID field 88 does not exist. Only found 7 fields.", $e->getMessage());
-        }
+        new Reader(static::WDB5_PATH . '/BadIdField.db2');
     }
 
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Expected ID field 5 reportedly has 2 values per row
+     */
     public function testBadIdFieldCount()
     {
-        try {
-            $reader = new Reader(static::WDB5_PATH . '/BadIdFieldCount.db2');
-            $this->fail("No exception raised with bad ID field count in header");
-        } catch (Exception $e) {
-            $this->assertEquals("Expected ID field 5 reportedly has 2 values per row", $e->getMessage());
-        }
+        new Reader(static::WDB5_PATH . '/BadIdFieldCount.db2');
     }
 
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Could not find end of embedded string 2 x 0 in record 0
+     */
     public function testEmbedStringNoEnd()
     {
-        try {
-            $reader = new Reader(static::WDB5_PATH . '/EmbedStringsNoEnd.db2', [2]);
-            $this->fail("No exception raised with bad embedded string record");
-        } catch (Exception $e) {
-            $this->assertEquals("Could not find end of embedded string 2 x 0 in record 0", $e->getMessage());
-        }
+        new Reader(static::WDB5_PATH . '/EmbedStringsNoEnd.db2', [2]);
     }
 
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Copy block referenced ID 10066329 which does not exist
+     */
     public function testCopyBlockReferenceMissingId()
     {
-        try {
-            $reader = new Reader(static::WDB5_PATH . '/BadCopyBlock.db2', [2]);
-            $this->fail("No exception raised with bad copy block reference");
-        } catch (Exception $e) {
-            $this->assertEquals("Copy block referenced ID 10066329 which does not exist", $e->getMessage());
-        }
+        new Reader(static::WDB5_PATH . '/BadCopyBlock.db2', [2]);
     }
 
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage You may only pass an array of string fields when loading a DB2
+     */
     public function testInvalidStringFields()
     {
-        try {
-            $reader = new Reader(static::WDB5_PATH . '/EmbedStrings.db2', 'invalid');
-            $this->fail("No exception raised during construction with bad string fields argument");
-        } catch (Exception $e) {
-            $this->assertEquals("You may only pass an array of string fields when loading a DB2", $e->getMessage());
-        }
+        new Reader(static::WDB5_PATH . '/EmbedStrings.db2', 'invalid');
     }
 
     public function testLastFieldNotArray()
@@ -485,43 +460,43 @@ class ReaderTest extends phpunit\framework\TestCase
         $this->assertEquals([96], $adbViaMethod->getRecord(150));
     }
 
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Unknown DB2 format: WCH7 in file idblock.adb.
+     */
     public function testAdbInvalidConstructor()
     {
-        try {
-            $reader = new Reader(static::WDB5_PATH . '/IdBlock.adb');
-            $this->fail("No exception raised trying to open an ADB without a DB2");
-        } catch (Exception $e) {
-            $this->assertEquals("Unknown DB2 format: WCH7", $e->getMessage());
-        }
+        new Reader(static::WDB5_PATH . '/IdBlock.adb');
     }
 
-    public function testDb2IsNotAdb()
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Unknown ADB format: WDB5 in file idblock.db2.
+     */
+    public function testOpenDb2AsAdb()
     {
         $db2 = new Reader(static::WDB5_PATH . '/IdBlock.db2');
-        try {
-            $adbViaConstructor = new Reader(static::WDB5_PATH . '/IdBlock.db2', $db2);
-            $this->fail("No exception raised trying to open an DB2 as an ADB via Constructor");
-        } catch (Exception $e) {
-            $this->assertEquals("Unknown ADB format: WDB5", $e->getMessage());
-        }
-
-        try {
-            $adbViaMethod = $db2->loadAdb(static::WDB5_PATH . '/IdBlock.db2');
-            $this->fail("No exception raised trying to open an DB2 as an ADB via Method");
-        } catch (Exception $e) {
-            $this->assertEquals("Unknown ADB format: WDB5", $e->getMessage());
-        }
+        new Reader(static::WDB5_PATH . '/IdBlock.db2', $db2);
     }
 
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Unknown ADB format: WDB5 in file idblock.db2.
+     */
+    public function testOpenDb2AsAdbViaMethod()
+    {
+        $db2 = new Reader(static::WDB5_PATH . '/IdBlock.db2');
+        $db2->loadAdb(static::WDB5_PATH . '/IdBlock.db2');
+    }
+
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Expected size: 1329, actual size: 59
+     */
     public function testBadAdbLength()
     {
         $db2 = new Reader(static::WDB5_PATH . '/IdBlock.db2');
-        try {
-            $adb = new Reader(static::WDB5_PATH . '/BadLength.adb', $db2);
-            $this->fail("No exception raised with a truncated ADB file");
-        } catch (Exception $e) {
-            $this->assertEquals("Expected size: 1329, actual size: 59", $e->getMessage());
-        }
+        new Reader(static::WDB5_PATH . '/BadLength.adb', $db2);
     }
 
     public function testAdbWithEmbeddedStrings()
@@ -532,26 +507,24 @@ class ReaderTest extends phpunit\framework\TestCase
         $this->assertEquals([1221,123321,'ADB',321123], $adb->getRecord(175));
     }
 
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage locale of embedstringswronglocale.adb (2) does not match locale of embedstrings.db2 (1)
+     */
     public function testAdbLocaleMismatch()
     {
         $db2 = new Reader(static::WDB5_PATH . '/EmbedStrings.db2');
-        try {
-            $adb = new Reader(static::WDB5_PATH . '/EmbedStringsWrongLocale.adb', $db2);
-            $this->fail("No exception raised with the wrong locale in the ADB file");
-        } catch (Exception $e) {
-            $this->assertEquals("locale of embedstringswronglocale.adb (2) does not match locale of embedstrings.db2 (1)", $e->getMessage());
-        }
+        new Reader(static::WDB5_PATH . '/EmbedStringsWrongLocale.adb', $db2);
     }
 
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage layoutHash of embedstringswronghash.adb (2913643194) does not match layoutHash of embedstrings.db2 (4022250974)
+     */
     public function testAdbHashMismatch()
     {
         $db2 = new Reader(static::WDB5_PATH . '/EmbedStrings.db2');
-        try {
-            $adb = new Reader(static::WDB5_PATH . '/EmbedStringsWrongHash.adb', $db2);
-            $this->fail("No exception raised with the wrong locale in the ADB file");
-        } catch (Exception $e) {
-            $this->assertEquals("layoutHash of embedstringswronghash.adb (2913643194) does not match layoutHash of embedstrings.db2 (4022250974)", $e->getMessage());
-        }
+        new Reader(static::WDB5_PATH . '/EmbedStringsWrongHash.adb', $db2);
     }
 
     public function testGetFieldTypes()


### PR DESCRIPTION
- Added composer support
- Relocated main class to be compliant with PSR-4 standards (see composer.json)
- Added phpunit dev-dependency. Simply run `vendor/bin/phpunit` to run
- Added some phpdocs to class methods.
- Updated unit-tests to use `@expectedException` and `@expectedExceptionMessage`
- Updated exceptions to use `sprintf` instead of embedding variables directly in error messages

The package still needs to be added to packagist.org, but I'll leave this to you, since you'll probably want to add a git-hook to it so it gets updated automatically when you create new tags. You'll need to set-up a service hook in the configuration of this repository in order to do this. More info here: https://packagist.org/about under caption "GitHub Service Hook"
